### PR TITLE
Adding local OpenTelemetry setup

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+OTEL_ENDPOINT=otel-collector:4317

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@
 
 # Go workspace file
 go.work
+
+.env.secret

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,10 @@
 NAME = d4bot
 VERSION := $(shell cat version)
 
+.PHONY: up
+up:
+	docker-compose up -d
+
 .PHONY: build
 build:
 	docker build -t ${NAME} .

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Tools needed:
 
 ## Running the bot locally
 
-Set the `DISCORD_BOT_TOKEN` environment variable to the generated bot token and then run `make run`.
+Create a `.env.secret` file in the root of the project and put `BOT_TOKEN={bot_token_secret}` into the file. Next, run `make up`.

--- a/cmd/otel/tracing.go
+++ b/cmd/otel/tracing.go
@@ -24,6 +24,7 @@ func InitTracing(ctx context.Context, collectorEndpoint string) func() {
 
 	client := otlptracegrpc.NewClient([]otlptracegrpc.Option{
 		otlptracegrpc.WithEndpoint(collectorEndpoint),
+		otlptracegrpc.WithInsecure(),
 	}...)
 	exporter, err := otlptrace.New(ctx, client)
 	if err != nil {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,36 @@
+version: "3.8"
+services:
+  d4:
+    image: dillonad/d4bot:latest
+    container_name: d4
+    env_file:
+      - .env
+      - .env.local
+    networks:
+      - d4bot
+
+  otel-collector:
+    container_name: otel-collector
+    image: ghcr.io/open-telemetry/opentelemetry-collector-releases/opentelemetry-collector-contrib:latest
+    volumes:
+      - ./otel-config.yaml:/etc/otelcol-contrib/config.yaml:Z
+    ports:
+      - "4317:4317"
+    networks:
+      - d4bot
+
+  jaeger-ui:
+    container_name: jaeger-ui
+    image: docker.io/jaegertracing/all-in-one
+    ports:
+      # Data port
+      - "14250:14250"
+      # UI Port
+      - "16686:16686"
+    networks:
+      - d4bot
+    depends_on:
+      - otel-collector
+
+networks:
+  d4bot:

--- a/otel-config.yaml
+++ b/otel-config.yaml
@@ -1,0 +1,33 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+processors:
+  batch:
+
+exporters:
+
+  jaeger:
+    endpoint: jaeger-ui:14250
+    tls:
+      insecure: true
+
+  logging:
+
+extensions:
+  health_check:
+  pprof:
+  zpages:
+
+service:
+  extensions: [health_check,pprof,zpages]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [jaeger]
+    metrics:
+      receivers: [otlp]
+      processors: [batch]
+      exporters: [logging]


### PR DESCRIPTION
Adding OTEL Collector and Jaeger to be able to collect and view local traces. Once everything is running, the traces will be visible at `http://localhost:16686`.

<img width="1716" alt="image" src="https://github.com/DillonAd/d4bot/assets/28228453/6133f6ff-3493-49c6-99b1-50cd87b65603">
